### PR TITLE
fix-blurhash-loadError

### DIFF
--- a/src/components/Blurhash/Blurhash.tsx
+++ b/src/components/Blurhash/Blurhash.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import BlurhashCanvas from '../BlurhashCanvas/BlurhasCanvas';
+
+type Props = React.HTMLAttributes<HTMLDivElement> & {
+  hash: string;
+  /** CSS height, default: 128 */
+  height?: number | string | 'auto';
+  punch?: number;
+  resolutionX?: number;
+  resolutionY?: number;
+  style?: React.CSSProperties;
+  /** CSS width, default: 128 */
+  width?: number | string | 'auto';
+};
+
+const canvasStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  width: '100%',
+  height: '100%'
+};
+
+export default class Blurhash extends React.PureComponent<Props> {
+  static defaultProps = {
+    height: 128,
+    width: 128,
+    resolutionX: 32,
+    resolutionY: 32
+  };
+
+  componentDidUpdate() {
+    if (this.props.resolutionX <= 0) {
+      throw new Error('resolutionX must be larger than zero');
+    }
+
+    if (this.props.resolutionY <= 0) {
+      throw new Error('resolutionY must be larger than zero');
+    }
+  }
+
+  render() {
+    const { hash, height, width, punch, resolutionX, resolutionY, style, ...rest } = this.props;
+
+    return (
+      <div
+        {...rest}
+        style={{ display: 'inline-block', height, width, ...style, position: 'relative' }}
+      >
+        <BlurhashCanvas
+          hash={hash}
+          height={resolutionY}
+          width={resolutionX}
+          punch={punch}
+          style={canvasStyle}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/BlurhashCanvas/BlurhasCanvas.tsx
+++ b/src/components/BlurhashCanvas/BlurhasCanvas.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { decode } from 'blurhash';
+
+export type Props = React.CanvasHTMLAttributes<HTMLCanvasElement> & {
+  hash: string;
+  height?: number;
+  punch?: number;
+  width?: number;
+};
+
+export default class BlurhashCanvas extends React.PureComponent<Props> {
+  static defaultProps = {
+    height: 128,
+    width: 128
+  };
+
+  canvas: HTMLCanvasElement = null;
+
+  componentDidUpdate() {
+    this.draw();
+  }
+
+  handleRef = (canvas: HTMLCanvasElement) => {
+    this.canvas = canvas;
+    this.draw();
+  };
+
+  draw = () => {
+    const { hash, height, punch, width } = this.props;
+
+    if (this.canvas) {
+      const pixels = decode(hash, width, height, punch);
+
+      const ctx = this.canvas.getContext('2d');
+      const imageData = ctx.createImageData(width, height);
+      imageData.data.set(pixels);
+      ctx.putImageData(imageData, 0, 0);
+    }
+  };
+
+  render() {
+    const { hash, height, width, ...rest } = this.props;
+
+    return <canvas {...rest} height={height} width={width} ref={this.handleRef} />;
+  }
+}

--- a/src/components/Restaurant/Restaurant.tsx
+++ b/src/components/Restaurant/Restaurant.tsx
@@ -1,5 +1,5 @@
 import React, { useState, FunctionComponent } from 'react';
-import { Blurhash } from 'react-blurhash';
+import Blurhash from '../Blurhash/Blurhash';
 import ContentsLoader from '../ContentsLoader/ContentsLoader';
 import { IPropRestaurant } from '../../index.d';
 import styled from 'styled-components';


### PR DESCRIPTION
- Add blurhash components directly to the project than importing libraries

There was an error(such as 'TypeError: cannot read property 'purecomponent' of undefined') when running the project locally or when trying to write test code.
The added components are from Wolt official github page(https://github.com/woltapp/blurhash/tree/master/TypeScript).

